### PR TITLE
Docker: Separated rubygems from source-files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ USER app
 # Working directory
 WORKDIR /usr/src/app
 
-# Copy source-files
-COPY --chown=app:app Gemfile Gemfile.lock config.ru webserver.rb model.rb ./
+# Copy bundler Gemfile for rubygems
+COPY --chown=app:app Gemfile Gemfile.lock ./
 
 # Ruby-Gems
 RUN bundle lock --update && \
     bundle install --jobs=4
+
+# Copy source-files
+COPY --chown=app:app config.ru webserver.rb model.rb ./
 
 # Send "ctrl-c"-like signal when stopping
 STOPSIGNAL SIGINT


### PR DESCRIPTION
Copying Gemfile & Gemfile.lock together with the source code in
Dockerfile causes bundler to install all gems on each change of source
code (like config.ru) even if there was no change in the rubygems
dependencies.

Facilitating docker image layer cache, it is possible to cache the bundle
install step. If only the source code is changed, rubygems are not
installed again, but the exiting docker image layer cache is used.